### PR TITLE
Add option to instantiate MolFileReader with mol str

### DIFF
--- a/pikachu/chem/molfile/read_molfile.py
+++ b/pikachu/chem/molfile/read_molfile.py
@@ -1,6 +1,5 @@
 from pikachu.chem.structure import Structure
 from pikachu.chem.atom import Atom
-from pikachu.chem.bond import Bond
 from pikachu.math_functions import Vector
 
 
@@ -45,11 +44,11 @@ class MolFileReader:
             # atom_isotope = int(atom_info[34:36])
             atom_charge = self.value_to_charge[int(atom_info[36:39])]
             atom_id = i
-            
+
             atom = Atom(atom_type, atom_id, None, atom_charge, False)
             atom.draw.set_position(Vector(atom_x, atom_y))
             self.structure.add_disconnected_atom(atom)
-            
+
     def parse_bond_info(self, bonds):
         for i, bond_info in enumerate(bonds):
             atom_1_nr = int(bond_info[:3]) - 1
@@ -73,15 +72,10 @@ class MolFileReader:
             counts = molfile.readline()
             atom_counts = int(counts[:3])
             bond_counts = int(counts[3:6])
-            for i in range(atom_counts):
+            for _ in range(atom_counts):
                 atom_info = molfile.readline()
                 atoms.append(atom_info)
-            for i in range(bond_counts):
+            for _ in range(bond_counts):
                 bond_info = molfile.readline()
                 bonds.append(bond_info)
         return atoms, bonds
-                
-
-
-
-

--- a/pikachu/chem/molfile/read_molfile.py
+++ b/pikachu/chem/molfile/read_molfile.py
@@ -74,8 +74,8 @@ class MolFileReader:
         if self.molfile_str:
             molfile_lines = self.molfile_str.split('\n')
         else:
-            with open(self.molfile_path, 'r') as molfile:
-                molfile_lines = molfile.read()
+            with open(self.molfile_path, 'r') as mol_file:
+                molfile_lines = mol_file.read()
                 molfile_lines = molfile_lines.split('\n')
         return molfile_lines
 

--- a/pikachu/chem/molfile/read_molfile.py
+++ b/pikachu/chem/molfile/read_molfile.py
@@ -21,16 +21,16 @@ class MolFileReader:
                               1: '/',
                               6: '\\'}
 
-    def __init__(self, molfile_str=False, molfile_path=False):
+    def __init__(self, molfile=False, molfile_str=False):
         # Instantiate MolFileReader with mol_file_str or mol_file_path
         self.molfile_str = molfile_str
-        self.molfile_path = molfile_path
+        self.molfile_path = molfile
         # Raise error when not enough arguments were given
         err = "molfile_str or molfile_path needed to instantiate MolFileReader"
-        if not molfile_path and not molfile_str:
+        if not molfile and not molfile_str:
             raise ValueError(err)
         # Raise error when too many arguments were given
-        if not molfile_path and not molfile_str:
+        if not molfile and not molfile_str:
             raise ValueError(f'{err} (both were given)')
         self.molfile_lines = self.get_molfile_lines()
         self.structure = Structure()

--- a/validation/test_read_molfile.py
+++ b/validation/test_read_molfile.py
@@ -1,0 +1,38 @@
+import os
+from pikachu.chem.molfile.read_molfile import MolFileReader
+
+"""
+Unit tests for MolFileReader class
+"""
+
+
+class TestMolFileReader:
+    # Define test molfile_path and molefile_str
+    test_dir = os.path.split(__file__)[0]
+    molfile_path = os.path.join(test_dir, 'temp.mol')
+    with open(molfile_path, 'r') as molfile:
+        molfile_str = molfile.read()
+
+    def test_constructor(self):
+        # Make sure instantiation fails when no args are given
+        try:
+            MolFileReader()
+        except Exception as exception:
+            assert type(exception) == ValueError
+        # Make sure instantiation fails when both args are given
+        try:
+            MolFileReader(self.molfile_str, self.molfile_path)
+        except Exception as exception:
+            assert type(exception) == ValueError
+        # Make sure instantiation works with molfile_path given
+        assert MolFileReader(self.molfile_path)
+        # Make sure instantiation works with molfile_str given
+        assert MolFileReader(self.molfile_str)
+
+    def test_get_molfile_lines(self):
+        # Assert that reading from file/str makes no difference
+        reader_from_path = MolFileReader(molfile_path=self.molfile_path)
+        reader_from_str = MolFileReader(molfile_str=self.molfile_str)
+        lines_from_path = reader_from_path.get_molfile_lines()
+        lines_from_str = reader_from_str.get_molfile_lines()
+        assert lines_from_path == lines_from_str

--- a/validation/test_read_molfile.py
+++ b/validation/test_read_molfile.py
@@ -25,13 +25,13 @@ class TestMolFileReader:
         except Exception as exception:
             assert type(exception) == ValueError
         # Make sure instantiation works with molfile_path given
-        assert MolFileReader(self.molfile_path)
+        assert MolFileReader(molfile=self.molfile_path)
         # Make sure instantiation works with molfile_str given
-        assert MolFileReader(self.molfile_str)
+        assert MolFileReader(molfile_str=self.molfile_str)
 
     def test_get_molfile_lines(self):
         # Assert that reading from file/str makes no difference
-        reader_from_path = MolFileReader(molfile_path=self.molfile_path)
+        reader_from_path = MolFileReader(molfile=self.molfile_path)
         reader_from_str = MolFileReader(molfile_str=self.molfile_str)
         lines_from_path = reader_from_path.get_molfile_lines()
         lines_from_str = reader_from_str.get_molfile_lines()


### PR DESCRIPTION
#### Added a convenience function:
- Added the option to instantiate MolFileReader with the String content of a molfile instead of the path of the molfile
- Everything else should behave the same way, the constructor of MolFileReader now simply also accepts and processes the argument molfile_str if the normal "molfile" argument is not given
- Added unit tests for the things I have touched to make sure it behaves the way it is supposed to behave