### PR TITLE
Allow depiction of markush structures

### DIFF
--- a/pikachu/chem/atom_properties.py
+++ b/pikachu/chem/atom_properties.py
@@ -49,7 +49,7 @@ class AtomProperties:
             if info_dict_name[0] != '_':
                 info_dict = getattr(self, info_dict_name)
                 if type(info_dict) == dict:
-                    if 'Xe' in info_dict.keys():
+                    if 'C' in info_dict.keys():
                         r_group_dict = {symbol: info_dict['C']
                                         for symbol
                                         in r_group_symbols_with_indices}

--- a/pikachu/chem/atom_properties.py
+++ b/pikachu/chem/atom_properties.py
@@ -35,6 +35,27 @@ class AtomProperties:
         orbital number the number of orbitals of that type an atom has
 
     """
+
+    def __init__(self):
+        # Define R group variables as '[RXZ][0-99]?'
+        indices = [str(index) for index in range(100)]
+        r_group_symbols = ['R', 'X', 'Z']
+        r_group_symbols_with_indices = ['R', 'X', 'Z']
+        for symbol in r_group_symbols:
+            for index in indices:
+                r_group_symbols_with_indices.append(symbol + index)
+        # Add R group variables and treat them like "C"
+        for info_dict_name in dir(self):
+            if info_dict_name[0] != '_':
+                info_dict = getattr(self, info_dict_name)
+                if type(info_dict) == dict:
+                    if 'Xe' in info_dict.keys():
+                        r_group_dict = {symbol: info_dict['C']
+                                        for symbol
+                                        in r_group_symbols_with_indices}
+                        info_dict.update(r_group_dict)
+                        setattr(self, info_dict_name, info_dict)
+
     element_to_valences = {'C': [4],
                            'O': [2],
                            'N': [3],
@@ -611,7 +632,8 @@ class AtomProperties:
               'Pu', 'Am', 'Cm', 'Bk', 'Cf', 'Es', 'Fm', 'Md', 'No', 'Lr', 'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt', 'Ds',
               'Rg', 'Cn', 'Nh', 'Fl', 'Mc', 'Lv'}
 
-    organic = {'C', 'O', 'N', 'P', 'H', 'S', 'Cl', 'Br', 'I', 'F', '*'}
+    organic = {'C', 'O', 'N', 'P', 'H', 'S',
+               'Cl', 'Br', 'I', 'F', '*'}
 
     element_to_atomic_group = {'H': 1,
                                '*': 1,

--- a/pikachu/drawing/drawing.py
+++ b/pikachu/drawing/drawing.py
@@ -1078,6 +1078,7 @@ class Drawer:
         canvas.draw()
         image = np.frombuffer(canvas.tostring_rgb(), dtype='uint8')
         image = image.reshape(canvas.get_width_height()[::-1] + (3,))
+        plt.close('all')
         return image
 
     @staticmethod

--- a/pikachu/drawing/drawing.py
+++ b/pikachu/drawing/drawing.py
@@ -1549,9 +1549,13 @@ class Drawer:
 
     def set_r_group_indices_subscript(self, atom_text: str) -> str:
         # Take str and return the same str with subscript digits
-        # (the only atom_types that contain digits are R groups)
+        # (pattern is necessary to not to get confused with isotopes)
         sub_translation = str.maketrans("0123456789", "₀₁₂₃₄₅₆₇₈₉")
-        atom_text = atom_text.translate(sub_translation)
+        match = re.search('[RXZ]\d+', atom_text)
+        if match:
+            matched_pattern = match.group()
+            adapted_pattern = matched_pattern.translate(sub_translation)
+            atom_text = atom_text.replace(matched_pattern, adapted_pattern)
         return atom_text
 
     @staticmethod

--- a/pikachu/drawing/drawing.py
+++ b/pikachu/drawing/drawing.py
@@ -1548,14 +1548,10 @@ class Drawer:
                              color=atom.draw.colour)
 
     def set_r_group_indices_subscript(self, atom_text: str) -> str:
-        # Takes atom type text and adapts it so that R group indices are
-        # drawn as subscript characters
+        # Take str and return the same str with subscript digits
+        # (the only atom_types that contain digits are R groups)
         sub_translation = str.maketrans("0123456789", "₀₁₂₃₄₅₆₇₈₉")
-        match = re.search('[RXZ]\d+', atom_text)
-        if match:
-            matched_pattern = match.group()
-            adapted_pattern = matched_pattern.translate(sub_translation)
-            atom_text = atom_text.replace(matched_pattern, adapted_pattern)
+        atom_text = atom_text.translate(sub_translation)
         return atom_text
 
     @staticmethod

--- a/pikachu/drawing/drawing.py
+++ b/pikachu/drawing/drawing.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import copy
 import math
+import numpy as np
 from matplotlib import pyplot as plt
 from io import StringIO
 import re
@@ -1071,6 +1072,15 @@ class Drawer:
                 [line.point_1.y, line.point_2.y], color=color, linewidth=self.options.bond_thickness)
 
     @staticmethod
+    def get_image_as_array() -> np.ndarray:
+        # Return image as np.ndarray that represents RGB image
+        canvas = plt.gca().figure.canvas
+        canvas.draw()
+        image = np.frombuffer(canvas.tostring_rgb(), dtype='uint8')
+        image = image.reshape(canvas.get_width_height()[::-1] + (3,))
+        return image
+
+    @staticmethod
     def save_svg(out_file):
         if out_file.endswith('.svg'):
             pass
@@ -1090,7 +1100,6 @@ class Drawer:
         plt.clf()
         plt.close(plt.gcf())
         plt.close('all')
-        
         return svg
 
     @staticmethod

--- a/pikachu/drawing/drawing.py
+++ b/pikachu/drawing/drawing.py
@@ -1,18 +1,14 @@
 #!/usr/bin/env python
-import time
 import copy
 import math
-import matplotlib
 from matplotlib import pyplot as plt
-from pprint import pprint
 from io import StringIO
 import re
 
-from pikachu.drawing.sssr import SSSR
 from pikachu.drawing.rings import Ring, RingOverlap, find_neighbouring_rings, rings_connected_by_bridge, \
     find_bridged_systems
-from pikachu.math_functions import Vector, Polygon, Line, Permutations
-from pikachu.chem.chirality import find_chirality_from_nonh, get_chiral_permutations, get_chiral_permutations_lonepair
+from pikachu.math_functions import Vector, Polygon, Line
+from pikachu.chem.chirality import get_chiral_permutations, get_chiral_permutations_lonepair
 from pikachu.chem.atom_properties import ATOM_PROPERTIES
 from pikachu.errors import DrawingError
 
@@ -22,7 +18,7 @@ def draw_multiple(structure, coords_only=False, options=None):
         options = Options()
     options_main = Options()
     options_main.finetune = False
-        
+
     drawer = Drawer(structure, options=options_main, coords_only=True, multiple=True)
     structures = structure.split_disconnected_structures()
     max_x = -100000000

--- a/pikachu/drawing/drawing.py
+++ b/pikachu/drawing/drawing.py
@@ -6,6 +6,7 @@ import matplotlib
 from matplotlib import pyplot as plt
 from pprint import pprint
 from io import StringIO
+import re
 
 from pikachu.drawing.sssr import SSSR
 from pikachu.drawing.rings import Ring, RingOverlap, find_neighbouring_rings, rings_connected_by_bridge, \
@@ -1382,7 +1383,7 @@ class Drawer:
                     if atom.type == 'C':
                         text = '.'
                     else:
-                        text = atom.type
+                        text = self.set_r_group_indices_subscript(atom.type)
                 else:
                     text = ''
 
@@ -1545,6 +1546,17 @@ class Drawer:
                              horizontalalignment='center',
                              verticalalignment='center',
                              color=atom.draw.colour)
+
+    def set_r_group_indices_subscript(self, atom_text: str) -> str:
+        # Takes atom type text and adapts it so that R group indices are
+        # drawn as subscript characters
+        sub_translation = str.maketrans("0123456789", "₀₁₂₃₄₅₆₇₈₉")
+        match = re.search('[RXZ]\d+', atom_text)
+        if match:
+            matched_pattern = match.group()
+            adapted_pattern = matched_pattern.translate(sub_translation)
+            atom_text = atom_text.replace(matched_pattern, adapted_pattern)
+        return atom_text
 
     @staticmethod
     def is_terminal(atom):

--- a/pikachu/smiles/smiles.py
+++ b/pikachu/smiles/smiles.py
@@ -36,11 +36,15 @@ def parse_explicit(component):
     chirals = []
 
     for i, character in enumerate(informative):
+        last = informative[i-1]
+        if len(informative) > 2 and i > 1:
+            second_last = informative[i-2]
+        else:
+            second_last = ''
         if skip:
             skip = False
             continue
         if character.isupper():
-
             if character == 'H':
                 if not (len(informative) >= 2 and informative[1] in {'o', 'e', 'f', 's'}):
                     hydrogen = i
@@ -60,6 +64,11 @@ def parse_explicit(component):
                 except IndexError:
                     element.append(i)
         elif character.islower():
+            element.append(i)
+        # Add indices of R groups to the element symbol
+        elif character.isdigit() and informative[i-1] in ['R', 'X', 'Z']:
+            element.append(i)
+        elif (character + last).isdigit() and second_last in ['R', 'X', 'Z']:
             element.append(i)
         elif character.isdigit():
             numbers.append(i)

--- a/validation/test_drawing.py
+++ b/validation/test_drawing.py
@@ -1,0 +1,31 @@
+from pikachu.general import read_smiles
+from pikachu.drawing.drawing import Drawer
+
+
+class TestDrawer:
+    def test_set_r_group_indices_subscript(self):
+        # Test that only R group indices are returned as subscript
+        dummy_structure = read_smiles("CC")
+        drawer = Drawer(dummy_structure)
+        test_str = ['c1',
+                    'C1',
+                    'C',
+                    'O',
+                    '13',
+                    'R',
+                    'R1',
+                    'X23',
+                    'Z54']
+        expected_str = ['c1',
+                        'C1',
+                        'C',
+                        'O',
+                        '13',
+                        'R',
+                        'R₁',
+                        'X₂₃',
+                        'Z₅₄']
+        for index in range(len(test_str)):
+            result = drawer.set_r_group_indices_subscript(test_str[index])
+            expected = expected_str[index]
+            assert result == expected

--- a/validation/test_drawing.py
+++ b/validation/test_drawing.py
@@ -9,6 +9,7 @@ class TestDrawer:
         drawer = Drawer(dummy_structure)
         test_str = ['Xe',
                     'C',
+                    '13C',
                     'O',
                     'R',
                     'R1',
@@ -16,6 +17,7 @@ class TestDrawer:
                     'Z54']
         expected_str = ['Xe',
                         'C',
+                        '13C',
                         'O',
                         'R',
                         'R₁',

--- a/validation/test_drawing.py
+++ b/validation/test_drawing.py
@@ -7,20 +7,16 @@ class TestDrawer:
         # Test that only R group indices are returned as subscript
         dummy_structure = read_smiles("CC")
         drawer = Drawer(dummy_structure)
-        test_str = ['c1',
-                    'C1',
+        test_str = ['Xe',
                     'C',
                     'O',
-                    '13',
                     'R',
                     'R1',
                     'X23',
                     'Z54']
-        expected_str = ['c1',
-                        'C1',
+        expected_str = ['Xe',
                         'C',
                         'O',
-                        '13',
                         'R',
                         'R₁',
                         'X₂₃',


### PR DESCRIPTION
I tried to read structures with R-group from SMILES to depict them with PIKAChU and failed. Hence, I made some changes to enable it:
#### atomproperties.py:
- Added constructor that adds "R", "X" and "Z" as well as combinations of these variables with indices (0-99) to the atom property dictionaries
- *Discussion point*: There is a bit of a problem when it comes to how to handle these "atoms" as the R group variables can represent many different things. Right now, they are treated like carbon atoms. This can lead to "Rogue electron" warnings when constructing a molecule from a SMILES string. My first thought was to treat them like the existing placeholder variable "\*", but that comes with the problem that the R groups can then only be terminal. Something like "CC[X]CC" is not possible as "\*" is treated very similar to hydrogen atoms. Right now, I don't really have an idea for an elegant solution. When the R group variables are treated like carbon atoms, there are warnings, but everything is depicted correctly.
#### drawing.py:
- Added a function that recognises digits that come behind "R", "X" and "Z" and returns the same string with subscript digits (so that the depiction contains "R₁" instead of "R1").
#### test_drawing.py:
- Unit test for added function in drawing.py
#### smiles.py:
- Treat digits that come behind "R", "X" or "Z" as a part of the "element"

#### Result:
```
from pikachu.smiles.smiles import read_smiles
from pikachu.general import draw_structure

structure = read_smiles("[R12]C1C([X2])[X]([R])[Z]([Z1])=C([Z2])C1[X1]")
draw_structure(structure)
```
![image](https://user-images.githubusercontent.com/59618901/176427413-c67aefbf-4129-4a5b-84f0-29d830e67702.png)
